### PR TITLE
feat: Add Service Uptime Statistics Dashboard

### DIFF
--- a/UPTIME_STATISTICS.md
+++ b/UPTIME_STATISTICS.md
@@ -1,0 +1,112 @@
+# Service Uptime Statistics Dashboard
+
+This feature adds comprehensive uptime tracking and statistics for all services in the Vertex Service Manager.
+
+## Features Added
+
+### Backend Changes
+
+1. **Extended ServiceMetrics Model** (`internal/models/service_dependency.go`)
+   - Added `UptimeStatistics` struct with metrics like:
+     - Total restarts count
+     - Uptime percentage for 24h and 7d periods
+     - Mean Time Between Failures (MTBF)
+     - Total downtime tracking
+
+2. **Uptime Tracking Service** (`internal/services/uptime_tracking.go`)
+   - Singleton uptime tracker that records service state changes
+   - Calculates uptime percentages and downtime durations
+   - Tracks service restart events and failure patterns
+
+3. **Integration with Service Lifecycle**
+   - Added uptime event recording in service start/stop/restart operations
+   - Integrated with monitoring system to update uptime stats
+   - Automatic tracking of process failures and recoveries
+
+4. **New API Endpoints** (`internal/handlers/uptime_handler.go`)
+   - `GET /api/uptime/statistics` - Returns uptime stats for all services
+   - `GET /api/uptime/statistics/{id}` - Returns uptime stats for specific service
+
+### Frontend Changes
+
+1. **New React Component** (`web/src/components/UptimeStatistics/UptimeStatisticsDashboard.tsx`)
+   - Dashboard displaying service uptime statistics
+   - Real-time updates every 30 seconds
+   - Color-coded uptime percentages (green >99%, yellow >95%, red <95%)
+   - Formatted duration displays for downtime and MTBF
+
+2. **Updated Navigation** (`web/src/components/Sidebar/Sidebar.tsx`)
+   - Added "Uptime Stats" menu item with clock icon
+
+3. **Type Definitions** (`web/src/types.ts`)
+   - Added `UptimeStatistics` interface
+   - Updated `ServiceMetrics` to include uptime stats
+
+## API Usage
+
+### Get All Services Uptime Statistics
+```
+GET /api/uptime/statistics
+```
+
+Response:
+```json
+{
+  "statistics": {
+    "service-uuid": {
+      "serviceName": "example-service",
+      "serviceId": "service-uuid",
+      "port": 8080,
+      "status": "running",
+      "healthStatus": "healthy",
+      "stats": {
+        "totalRestarts": 3,
+        "uptimePercentage24h": 99.5,
+        "uptimePercentage7d": 98.2,
+        "mtbf": 86400000000000,
+        "lastDowntime": "2025-08-07T10:30:00Z",
+        "totalDowntime24h": 120000000000,
+        "totalDowntime7d": 1800000000000
+      }
+    }
+  },
+  "summary": {
+    "totalServices": 5,
+    "runningServices": 4,
+    "unhealthyServices": 1
+  }
+}
+```
+
+### Get Specific Service Uptime Statistics
+```
+GET /api/uptime/statistics/{service-id}
+```
+
+## Dashboard Features
+
+- **Summary Cards**: Quick overview of total, running, and unhealthy services
+- **Detailed Table**: Per-service uptime metrics including:
+  - 24-hour and 7-day uptime percentages
+  - Total restart count
+  - Mean Time Between Failures (MTBF)
+  - Total downtime in the last 24 hours
+- **Color Coding**: Visual indicators for uptime health
+- **Auto-Refresh**: Updates every 30 seconds
+- **Duration Formatting**: Human-readable time formats (e.g., "2d 4h 30m")
+
+## Benefits
+
+1. **Operational Insights**: Quickly identify problematic services
+2. **SLA Monitoring**: Track service availability against targets
+3. **Historical Trends**: Understand service reliability patterns
+4. **Proactive Maintenance**: Identify services requiring attention
+5. **Performance Tracking**: Monitor improvements over time
+
+## Implementation Notes
+
+- Uses singleton pattern for uptime tracker to ensure data consistency
+- Integrates seamlessly with existing monitoring infrastructure
+- Minimal performance impact with efficient event recording
+- Automatically handles service lifecycle events
+- Memory-efficient with event history limits (1000 events per service)

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -48,7 +48,7 @@ func (h *Handler) getServiceProjectsDir(serviceUUID string) string {
 	// Get global config as fallback
 	globalConfig := h.serviceManager.GetConfig()
 	defaultProjectsDir := globalConfig.ProjectsDir
-	
+
 	log.Printf("[DEBUG] getServiceProjectsDir - serviceUUID: %s, defaultProjectsDir: '%s'", serviceUUID, defaultProjectsDir)
 
 	// Query database to find all profiles that contain this service
@@ -94,7 +94,7 @@ func (h *Handler) getServiceProjectsDir(serviceUUID string) string {
 // Checks the user's active profile first, then falls back to global logic
 func (h *Handler) getServiceProjectsDirForUser(serviceUUID, userID string) string {
 	log.Printf("[DEBUG] getServiceProjectsDirForUser called - serviceUUID: %s, userID: %s", serviceUUID, userID)
-	
+
 	// First, try to get the user's active profile
 	activeProfile, err := h.profileService.GetActiveProfile(userID)
 	if err != nil {
@@ -110,7 +110,7 @@ func (h *Handler) getServiceProjectsDirForUser(serviceUUID, userID string) strin
 	if activeProfile != nil && activeProfile.ProjectsDir != "" {
 		log.Printf("[DEBUG] Active profile has ProjectsDir: %s", activeProfile.ProjectsDir)
 		log.Printf("[DEBUG] Active profile services: %v", activeProfile.Services)
-		
+
 		// Check if the service is in this profile
 		if slices.Contains(activeProfile.Services, serviceUUID) {
 			log.Printf("[INFO] Using active profile projects directory for service UUID %s: %s", serviceUUID, activeProfile.ProjectsDir)

--- a/internal/handlers/handlers.go
+++ b/internal/handlers/handlers.go
@@ -144,6 +144,7 @@ func (h *Handler) RegisterRoutes(r *mux.Router) {
 	registerCIRoutes(h, r)
 	registerConfigRoutes(h, r)
 	registerServiceRoutes(h, r)
+	registerUptimeRoutes(h, r)
 
 	// Service routes (will be protected later)
 	registerTopologyRoutes(h, r)

--- a/internal/handlers/uptime_handler.go
+++ b/internal/handlers/uptime_handler.go
@@ -46,13 +46,13 @@ func (h *Handler) getUptimeStatisticsHandler(w http.ResponseWriter, r *http.Requ
 				"status":       service.Status,
 				"healthStatus": service.HealthStatus,
 				"stats": map[string]interface{}{
-					"totalRestarts":      0,
+					"totalRestarts":       0,
 					"uptimePercentage24h": 100.0,
 					"uptimePercentage7d":  100.0,
-					"mtbf":              0,
-					"lastDowntime":      nil,
-					"totalDowntime24h":  0,
-					"totalDowntime7d":   0,
+					"mtbf":                0,
+					"lastDowntime":        nil,
+					"totalDowntime24h":    0,
+					"totalDowntime7d":     0,
 				},
 			}
 		}

--- a/internal/handlers/uptime_handler.go
+++ b/internal/handlers/uptime_handler.go
@@ -1,0 +1,141 @@
+// Package handlers - Uptime statistics handler
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/zechtz/vertex/internal/models"
+	"github.com/zechtz/vertex/internal/services"
+)
+
+func registerUptimeRoutes(h *Handler, r *mux.Router) {
+	r.HandleFunc("/api/uptime/statistics", h.getUptimeStatisticsHandler).Methods("GET")
+	r.HandleFunc("/api/uptime/statistics/{id}", h.getServiceUptimeStatisticsHandler).Methods("GET")
+}
+
+// getUptimeStatisticsHandler returns uptime statistics for all services
+func (h *Handler) getUptimeStatisticsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	uptimeTracker := services.GetUptimeTracker()
+	allStats := uptimeTracker.GetAllUptimeStats()
+
+	// Enhance with service names
+	serviceStats := make(map[string]interface{})
+	services := h.serviceManager.GetServices()
+
+	for _, service := range services {
+		if stats, exists := allStats[service.ID]; exists {
+			serviceStats[service.ID] = map[string]interface{}{
+				"serviceName":  service.Name,
+				"serviceId":    service.ID,
+				"port":         service.Port,
+				"status":       service.Status,
+				"healthStatus": service.HealthStatus,
+				"stats":        stats,
+			}
+		} else {
+			// Create default stats for services without events
+			serviceStats[service.ID] = map[string]interface{}{
+				"serviceName":  service.Name,
+				"serviceId":    service.ID,
+				"port":         service.Port,
+				"status":       service.Status,
+				"healthStatus": service.HealthStatus,
+				"stats": map[string]interface{}{
+					"totalRestarts":      0,
+					"uptimePercentage24h": 100.0,
+					"uptimePercentage7d":  100.0,
+					"mtbf":              0,
+					"lastDowntime":      nil,
+					"totalDowntime24h":  0,
+					"totalDowntime7d":   0,
+				},
+			}
+		}
+	}
+
+	response := map[string]interface{}{
+		"statistics": serviceStats,
+		"summary": map[string]interface{}{
+			"totalServices":     len(services),
+			"runningServices":   countRunningServices(services),
+			"unhealthyServices": countUnhealthyServices(services),
+		},
+	}
+
+	json.NewEncoder(w).Encode(response)
+}
+
+// getServiceUptimeStatisticsHandler returns uptime statistics for a specific service
+func (h *Handler) getServiceUptimeStatisticsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	vars := mux.Vars(r)
+	serviceID := vars["id"]
+
+	service, exists := h.serviceManager.GetServiceByUUID(serviceID)
+	if !exists {
+		http.Error(w, "Service not found", http.StatusNotFound)
+		return
+	}
+
+	uptimeTracker := services.GetUptimeTracker()
+	stats := uptimeTracker.CalculateUptimeStats(serviceID, service)
+
+	response := map[string]interface{}{
+		"serviceName":  service.Name,
+		"serviceId":    service.ID,
+		"port":         service.Port,
+		"status":       service.Status,
+		"healthStatus": service.HealthStatus,
+		"stats":        stats,
+	}
+
+	json.NewEncoder(w).Encode(response)
+}
+
+// Helper functions
+func countRunningServices(services []models.Service) int {
+	count := 0
+	for _, service := range services {
+		if service.Status == "running" {
+			count++
+		}
+	}
+	return count
+}
+
+func countUnhealthyServices(services []models.Service) int {
+	count := 0
+	for _, service := range services {
+		if service.Status == "running" && service.HealthStatus == "unhealthy" {
+			count++
+		}
+	}
+	return count
+}
+
+func getRunningServices(services []*models.Service) []*models.Service {
+	var running []*models.Service
+	for _, service := range services {
+		if service.Status == "running" {
+			running = append(running, service)
+		}
+	}
+	return running
+}
+
+func getUnhealthyServices(services []*models.Service) []*models.Service {
+	var unhealthy []*models.Service
+	for _, service := range services {
+		if service.Status == "running" && service.HealthStatus == "unhealthy" {
+			unhealthy = append(unhealthy, service)
+		}
+	}
+	return unhealthy
+}

--- a/internal/handlers/uptime_handler_test.go
+++ b/internal/handlers/uptime_handler_test.go
@@ -1,0 +1,247 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/zechtz/vertex/internal/models"
+)
+
+// ServiceManagerInterface for testing
+type ServiceManagerInterface interface {
+	GetServices() []models.Service
+	GetServiceByUUID(uuid string) (*models.Service, bool)
+}
+
+// MockServiceManager for testing
+type MockServiceManager struct{}
+
+func (msm *MockServiceManager) GetServices() []models.Service {
+	return []models.Service{
+		{
+			ID:           "test-service-1",
+			Name:         "Test Service 1",
+			Port:         8080,
+			Status:       "running",
+			HealthStatus: "healthy",
+		},
+		{
+			ID:           "test-service-2",
+			Name:         "Test Service 2",
+			Port:         8081,
+			Status:       "stopped",
+			HealthStatus: "unknown",
+		},
+	}
+}
+
+func (msm *MockServiceManager) GetServiceByUUID(uuid string) (*models.Service, bool) {
+	if uuid == "test-service-1" {
+		return &models.Service{
+			ID:           "test-service-1",
+			Name:         "Test Service 1",
+			Port:         8080,
+			Status:       "running",
+			HealthStatus: "healthy",
+		}, true
+	}
+	return nil, false
+}
+
+// MockHandler for testing
+type MockHandler struct {
+	serviceManager ServiceManagerInterface
+}
+
+func (h *MockHandler) getUptimeStatisticsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	services := h.serviceManager.GetServices()
+
+	serviceStats := make(map[string]interface{})
+	for _, service := range services {
+		serviceStats[service.ID] = map[string]interface{}{
+			"serviceName":  service.Name,
+			"serviceId":    service.ID,
+			"port":         service.Port,
+			"status":       service.Status,
+			"healthStatus": service.HealthStatus,
+			"stats": map[string]interface{}{
+				"totalRestarts":      0,
+				"uptimePercentage24h": 100.0,
+				"uptimePercentage7d":  100.0,
+				"mtbf":              0,
+				"lastDowntime":      nil,
+				"totalDowntime24h":  0,
+				"totalDowntime7d":   0,
+			},
+		}
+	}
+
+	response := map[string]interface{}{
+		"statistics": serviceStats,
+		"summary": map[string]interface{}{
+			"totalServices":     len(services),
+			"runningServices":   countRunningServices(services),
+			"unhealthyServices": countUnhealthyServices(services),
+		},
+	}
+
+	json.NewEncoder(w).Encode(response)
+}
+
+func (h *MockHandler) getServiceUptimeStatisticsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	vars := mux.Vars(r)
+	serviceID := vars["id"]
+
+	service, exists := h.serviceManager.GetServiceByUUID(serviceID)
+	if !exists {
+		http.Error(w, "Service not found", http.StatusNotFound)
+		return
+	}
+
+	response := map[string]interface{}{
+		"serviceName":  service.Name,
+		"serviceId":    service.ID,
+		"port":         service.Port,
+		"status":       service.Status,
+		"healthStatus": service.HealthStatus,
+		"stats": map[string]interface{}{
+			"totalRestarts":      0,
+			"uptimePercentage24h": 100.0,
+			"uptimePercentage7d":  100.0,
+			"mtbf":              0,
+			"lastDowntime":      nil,
+			"totalDowntime24h":  0,
+			"totalDowntime7d":   0,
+		},
+	}
+
+	json.NewEncoder(w).Encode(response)
+}
+
+func TestGetUptimeStatisticsHandler(t *testing.T) {
+	// Create a mock handler
+	mockServiceManager := &MockServiceManager{}
+	handler := &MockHandler{
+		serviceManager: mockServiceManager,
+	}
+
+	// Create request
+	req, err := http.NewRequest("GET", "/api/uptime/statistics", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create response recorder
+	rr := httptest.NewRecorder()
+
+	// Call the handler
+	handler.getUptimeStatisticsHandler(rr, req)
+
+	// Check status code
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	// Check response
+	var response map[string]interface{}
+	err = json.Unmarshal(rr.Body.Bytes(), &response)
+	if err != nil {
+		t.Errorf("could not parse response: %v", err)
+	}
+
+	// Verify response structure
+	if _, exists := response["statistics"]; !exists {
+		t.Error("response missing statistics field")
+	}
+
+	if _, exists := response["summary"]; !exists {
+		t.Error("response missing summary field")
+	}
+
+	// Check summary
+	summary := response["summary"].(map[string]interface{})
+	if summary["totalServices"] != float64(2) {
+		t.Errorf("expected 2 total services, got %v", summary["totalServices"])
+	}
+}
+
+func TestGetServiceUptimeStatisticsHandler(t *testing.T) {
+	// Create a mock handler
+	mockServiceManager := &MockServiceManager{}
+	handler := &MockHandler{
+		serviceManager: mockServiceManager,
+	}
+
+	// Create request with service ID
+	req, err := http.NewRequest("GET", "/api/uptime/statistics/test-service-1", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add URL vars (simulate mux router)
+	req = mux.SetURLVars(req, map[string]string{"id": "test-service-1"})
+
+	// Create response recorder
+	rr := httptest.NewRecorder()
+
+	// Call the handler
+	handler.getServiceUptimeStatisticsHandler(rr, req)
+
+	// Check status code
+	if status := rr.Code; status != http.StatusOK {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+	}
+
+	// Check response
+	var response map[string]interface{}
+	err = json.Unmarshal(rr.Body.Bytes(), &response)
+	if err != nil {
+		t.Errorf("could not parse response: %v", err)
+	}
+
+	// Verify response structure
+	if response["serviceName"] != "Test Service 1" {
+		t.Errorf("expected service name 'Test Service 1', got %v", response["serviceName"])
+	}
+
+	if response["serviceId"] != "test-service-1" {
+		t.Errorf("expected service ID 'test-service-1', got %v", response["serviceId"])
+	}
+}
+
+func TestGetServiceUptimeStatisticsHandler_NotFound(t *testing.T) {
+	// Create a mock handler
+	mockServiceManager := &MockServiceManager{}
+	handler := &MockHandler{
+		serviceManager: mockServiceManager,
+	}
+
+	// Create request with non-existent service ID
+	req, err := http.NewRequest("GET", "/api/uptime/statistics/non-existent", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add URL vars (simulate mux router)
+	req = mux.SetURLVars(req, map[string]string{"id": "non-existent"})
+
+	// Create response recorder
+	rr := httptest.NewRecorder()
+
+	// Call the handler
+	handler.getServiceUptimeStatisticsHandler(rr, req)
+
+	// Check status code
+	if status := rr.Code; status != http.StatusNotFound {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusNotFound)
+	}
+}

--- a/internal/handlers/uptime_handler_test.go
+++ b/internal/handlers/uptime_handler_test.go
@@ -71,13 +71,13 @@ func (h *MockHandler) getUptimeStatisticsHandler(w http.ResponseWriter, r *http.
 			"status":       service.Status,
 			"healthStatus": service.HealthStatus,
 			"stats": map[string]interface{}{
-				"totalRestarts":      0,
+				"totalRestarts":       0,
 				"uptimePercentage24h": 100.0,
 				"uptimePercentage7d":  100.0,
-				"mtbf":              0,
-				"lastDowntime":      nil,
-				"totalDowntime24h":  0,
-				"totalDowntime7d":   0,
+				"mtbf":                0,
+				"lastDowntime":        nil,
+				"totalDowntime24h":    0,
+				"totalDowntime7d":     0,
 			},
 		}
 	}
@@ -114,13 +114,13 @@ func (h *MockHandler) getServiceUptimeStatisticsHandler(w http.ResponseWriter, r
 		"status":       service.Status,
 		"healthStatus": service.HealthStatus,
 		"stats": map[string]interface{}{
-			"totalRestarts":      0,
+			"totalRestarts":       0,
 			"uptimePercentage24h": 100.0,
 			"uptimePercentage7d":  100.0,
-			"mtbf":              0,
-			"lastDowntime":      nil,
-			"totalDowntime24h":  0,
-			"totalDowntime7d":   0,
+			"mtbf":                0,
+			"lastDowntime":        nil,
+			"totalDowntime24h":    0,
+			"totalDowntime7d":     0,
 		},
 	}
 

--- a/internal/models/service_dependency.go
+++ b/internal/models/service_dependency.go
@@ -10,17 +10,17 @@ type ServiceMetrics struct {
 	RequestCount  uint64         `json:"requestCount"`
 	LastChecked   time.Time      `json:"lastChecked"`
 	// Uptime Statistics
-	UptimeStats   UptimeStatistics `json:"uptimeStats"`
+	UptimeStats UptimeStatistics `json:"uptimeStats"`
 }
 
 type UptimeStatistics struct {
-	TotalRestarts      int           `json:"totalRestarts"`
-	UptimePercentage24h float64      `json:"uptimePercentage24h"`
-	UptimePercentage7d  float64      `json:"uptimePercentage7d"`
-	MTBF               time.Duration `json:"mtbf"` // Mean Time Between Failures
-	LastDowntime       time.Time     `json:"lastDowntime"`
-	TotalDowntime24h   time.Duration `json:"totalDowntime24h"`
-	TotalDowntime7d    time.Duration `json:"totalDowntime7d"`
+	TotalRestarts       int           `json:"totalRestarts"`
+	UptimePercentage24h float64       `json:"uptimePercentage24h"`
+	UptimePercentage7d  float64       `json:"uptimePercentage7d"`
+	MTBF                time.Duration `json:"mtbf"` // Mean Time Between Failures
+	LastDowntime        time.Time     `json:"lastDowntime"`
+	TotalDowntime24h    time.Duration `json:"totalDowntime24h"`
+	TotalDowntime7d     time.Duration `json:"totalDowntime7d"`
 }
 
 type ServiceDependency struct {

--- a/internal/models/service_dependency.go
+++ b/internal/models/service_dependency.go
@@ -9,6 +9,18 @@ type ServiceMetrics struct {
 	ErrorRate     float64        `json:"errorRate"`
 	RequestCount  uint64         `json:"requestCount"`
 	LastChecked   time.Time      `json:"lastChecked"`
+	// Uptime Statistics
+	UptimeStats   UptimeStatistics `json:"uptimeStats"`
+}
+
+type UptimeStatistics struct {
+	TotalRestarts      int           `json:"totalRestarts"`
+	UptimePercentage24h float64      `json:"uptimePercentage24h"`
+	UptimePercentage7d  float64      `json:"uptimePercentage7d"`
+	MTBF               time.Duration `json:"mtbf"` // Mean Time Between Failures
+	LastDowntime       time.Time     `json:"lastDowntime"`
+	TotalDowntime24h   time.Duration `json:"totalDowntime24h"`
+	TotalDowntime7d    time.Duration `json:"totalDowntime7d"`
 }
 
 type ServiceDependency struct {

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -779,7 +779,15 @@ func (sm *Manager) RestartService(serviceUUID string) error {
 	}
 
 	// Start the service
-	return sm.startService(service)
+	err := sm.startService(service)
+	
+	// Record restart event if successful
+	if err == nil {
+		uptimeTracker := GetUptimeTracker()
+		uptimeTracker.RecordEvent(service.ID, "restart", "running")
+	}
+	
+	return err
 }
 
 // StartServiceWithProjectsDir starts a service using a specific projects directory

--- a/internal/services/manager.go
+++ b/internal/services/manager.go
@@ -780,13 +780,13 @@ func (sm *Manager) RestartService(serviceUUID string) error {
 
 	// Start the service
 	err := sm.startService(service)
-	
+
 	// Record restart event if successful
 	if err == nil {
 		uptimeTracker := GetUptimeTracker()
 		uptimeTracker.RecordEvent(service.ID, "restart", "running")
 	}
-	
+
 	return err
 }
 

--- a/internal/services/monitoring.go
+++ b/internal/services/monitoring.go
@@ -126,11 +126,11 @@ func (sm *Manager) collectAllServiceMetrics() {
 					service.PID = 0
 					service.Cmd = nil
 					service.Uptime = ""
-					
+
 					// Record uptime event
 					uptimeTracker := GetUptimeTracker()
 					uptimeTracker.RecordEvent(service.ID, "stop", "stopped")
-					
+
 					// Reset metrics
 					service.CPUPercent = 0
 					service.MemoryUsage = 0

--- a/internal/services/monitoring.go
+++ b/internal/services/monitoring.go
@@ -126,6 +126,11 @@ func (sm *Manager) collectAllServiceMetrics() {
 					service.PID = 0
 					service.Cmd = nil
 					service.Uptime = ""
+					
+					// Record uptime event
+					uptimeTracker := GetUptimeTracker()
+					uptimeTracker.RecordEvent(service.ID, "stop", "stopped")
+					
 					// Reset metrics
 					service.CPUPercent = 0
 					service.MemoryUsage = 0
@@ -137,7 +142,9 @@ func (sm *Manager) collectAllServiceMetrics() {
 					sm.broadcastUpdate(service)
 				}
 			} else {
-				// Successful metrics collection, broadcast update
+				// Successful metrics collection, update uptime stats and broadcast update
+				uptimeTracker := GetUptimeTracker()
+				service.Metrics.UptimeStats = uptimeTracker.CalculateUptimeStats(service.ID, service)
 				sm.broadcastUpdate(service)
 			}
 		}

--- a/internal/services/operations.go
+++ b/internal/services/operations.go
@@ -667,11 +667,11 @@ func (sm *Manager) startService(service *models.Service) error {
 		service.PID = 0
 		service.Cmd = nil
 		service.Uptime = ""
-		
+
 		// Record uptime event
 		uptimeTracker := GetUptimeTracker()
 		uptimeTracker.RecordEvent(service.ID, "stop", "stopped")
-		
+
 		sm.updateServiceInDB(service)
 		sm.broadcastUpdate(service)
 	}()
@@ -881,7 +881,7 @@ func isPortEnvironmentVariable(key string) bool {
 		"HTTP_PORT", "HTTPS_PORT", "WEB_PORT", "API_PORT", "TOMCAT_PORT",
 		"SPRING_SERVER_PORT", "MICROSERVICE_PORT", "APPLICATION_PORT",
 	}
-	
+
 	keyUpper := strings.ToUpper(key)
 	for _, portVar := range portVarNames {
 		if keyUpper == portVar || strings.HasSuffix(keyUpper, "_"+portVar) {

--- a/internal/services/operations.go
+++ b/internal/services/operations.go
@@ -633,6 +633,10 @@ func (sm *Manager) startService(service *models.Service) error {
 	service.LastStarted = time.Now()
 	service.Logs = []models.LogEntry{}
 
+	// Record uptime event
+	uptimeTracker := GetUptimeTracker()
+	uptimeTracker.RecordEvent(service.ID, "start", "running")
+
 	// Start reading logs
 	go sm.readLogs(service, stdout)
 	go sm.readLogs(service, stderr)
@@ -663,6 +667,11 @@ func (sm *Manager) startService(service *models.Service) error {
 		service.PID = 0
 		service.Cmd = nil
 		service.Uptime = ""
+		
+		// Record uptime event
+		uptimeTracker := GetUptimeTracker()
+		uptimeTracker.RecordEvent(service.ID, "stop", "stopped")
+		
 		sm.updateServiceInDB(service)
 		sm.broadcastUpdate(service)
 	}()

--- a/internal/services/uptime_tracking.go
+++ b/internal/services/uptime_tracking.go
@@ -70,8 +70,8 @@ func (ut *UptimeTracker) CalculateUptimeStats(serviceID string, service *models.
 		return models.UptimeStatistics{
 			UptimePercentage24h: 100.0,
 			UptimePercentage7d:  100.0,
-			MTBF:               0,
-			TotalRestarts:      0,
+			MTBF:                0,
+			TotalRestarts:       0,
 		}
 	}
 

--- a/internal/services/uptime_tracking.go
+++ b/internal/services/uptime_tracking.go
@@ -1,0 +1,251 @@
+// Package services - Uptime tracking functionality
+package services
+
+import (
+	"log"
+	"sync"
+	"time"
+
+	"github.com/zechtz/vertex/internal/models"
+)
+
+type UptimeEvent struct {
+	ServiceID string    `json:"serviceId"`
+	EventType string    `json:"eventType"` // "start", "stop", "restart"
+	Timestamp time.Time `json:"timestamp"`
+	Status    string    `json:"status"` // "running", "stopped", "unhealthy"
+}
+
+type UptimeTracker struct {
+	events map[string][]UptimeEvent // serviceID -> events
+	mutex  sync.RWMutex
+}
+
+var uptimeTracker *UptimeTracker
+var once sync.Once
+
+// GetUptimeTracker returns the singleton uptime tracker instance
+func GetUptimeTracker() *UptimeTracker {
+	once.Do(func() {
+		uptimeTracker = &UptimeTracker{
+			events: make(map[string][]UptimeEvent),
+		}
+	})
+	return uptimeTracker
+}
+
+// RecordEvent records a service state change event
+func (ut *UptimeTracker) RecordEvent(serviceID, eventType, status string) {
+	ut.mutex.Lock()
+	defer ut.mutex.Unlock()
+
+	event := UptimeEvent{
+		ServiceID: serviceID,
+		EventType: eventType,
+		Timestamp: time.Now(),
+		Status:    status,
+	}
+
+	if ut.events[serviceID] == nil {
+		ut.events[serviceID] = make([]UptimeEvent, 0)
+	}
+
+	ut.events[serviceID] = append(ut.events[serviceID], event)
+
+	// Keep only last 1000 events per service to prevent memory issues
+	if len(ut.events[serviceID]) > 1000 {
+		ut.events[serviceID] = ut.events[serviceID][len(ut.events[serviceID])-1000:]
+	}
+
+	log.Printf("[DEBUG] Recorded uptime event for %s: %s -> %s", serviceID, eventType, status)
+}
+
+// CalculateUptimeStats calculates uptime statistics for a service
+func (ut *UptimeTracker) CalculateUptimeStats(serviceID string, service *models.Service) models.UptimeStatistics {
+	ut.mutex.RLock()
+	defer ut.mutex.RUnlock()
+
+	events := ut.events[serviceID]
+	if len(events) == 0 {
+		return models.UptimeStatistics{
+			UptimePercentage24h: 100.0,
+			UptimePercentage7d:  100.0,
+			MTBF:               0,
+			TotalRestarts:      0,
+		}
+	}
+
+	now := time.Now()
+	day24h := now.Add(-24 * time.Hour)
+	day7d := now.Add(-7 * 24 * time.Hour)
+
+	stats := models.UptimeStatistics{}
+
+	// Count restarts and calculate MTBF
+	restarts := 0
+	var failures []time.Time
+	var lastDowntime time.Time
+
+	for _, event := range events {
+		if event.EventType == "restart" || (event.EventType == "start" && event.Status == "running") {
+			restarts++
+		}
+		if event.Status == "stopped" || event.Status == "unhealthy" {
+			failures = append(failures, event.Timestamp)
+			if event.Timestamp.After(lastDowntime) {
+				lastDowntime = event.Timestamp
+			}
+		}
+	}
+
+	stats.TotalRestarts = restarts
+	stats.LastDowntime = lastDowntime
+
+	// Calculate MTBF (Mean Time Between Failures)
+	if len(failures) > 1 {
+		totalTimeBetweenFailures := time.Duration(0)
+		for i := 1; i < len(failures); i++ {
+			totalTimeBetweenFailures += failures[i].Sub(failures[i-1])
+		}
+		stats.MTBF = totalTimeBetweenFailures / time.Duration(len(failures)-1)
+	}
+
+	// Calculate uptime percentages
+	stats.UptimePercentage24h = ut.calculateUptimePercentage(events, day24h, now)
+	stats.UptimePercentage7d = ut.calculateUptimePercentage(events, day7d, now)
+
+	// Calculate total downtime
+	stats.TotalDowntime24h = ut.calculateDowntime(events, day24h, now)
+	stats.TotalDowntime7d = ut.calculateDowntime(events, day7d, now)
+
+	return stats
+}
+
+// calculateUptimePercentage calculates uptime percentage within a time range
+func (ut *UptimeTracker) calculateUptimePercentage(events []UptimeEvent, start, end time.Time) float64 {
+	if len(events) == 0 {
+		return 100.0 // Assume 100% if no events recorded
+	}
+
+	totalTime := end.Sub(start)
+	downTime := time.Duration(0)
+	isDown := false
+	downStart := time.Time{}
+
+	// Check initial state at start time
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Timestamp.Before(start) {
+			if events[i].Status == "stopped" || events[i].Status == "unhealthy" {
+				isDown = true
+				downStart = start
+			}
+			break
+		}
+	}
+
+	// Process events within the time range
+	for _, event := range events {
+		if event.Timestamp.Before(start) {
+			continue
+		}
+		if event.Timestamp.After(end) {
+			break
+		}
+
+		if event.Status == "stopped" || event.Status == "unhealthy" {
+			if !isDown {
+				isDown = true
+				downStart = event.Timestamp
+			}
+		} else if event.Status == "running" || event.Status == "healthy" {
+			if isDown {
+				downTime += event.Timestamp.Sub(downStart)
+				isDown = false
+			}
+		}
+	}
+
+	// If still down at end time
+	if isDown {
+		downTime += end.Sub(downStart)
+	}
+
+	uptime := totalTime - downTime
+	if totalTime == 0 {
+		return 100.0
+	}
+
+	percentage := float64(uptime) / float64(totalTime) * 100
+	if percentage < 0 {
+		return 0.0
+	}
+	if percentage > 100 {
+		return 100.0
+	}
+
+	return percentage
+}
+
+// calculateDowntime calculates total downtime within a time range
+func (ut *UptimeTracker) calculateDowntime(events []UptimeEvent, start, end time.Time) time.Duration {
+	if len(events) == 0 {
+		return 0
+	}
+
+	downTime := time.Duration(0)
+	isDown := false
+	downStart := time.Time{}
+
+	// Check initial state at start time
+	for i := len(events) - 1; i >= 0; i-- {
+		if events[i].Timestamp.Before(start) {
+			if events[i].Status == "stopped" || events[i].Status == "unhealthy" {
+				isDown = true
+				downStart = start
+			}
+			break
+		}
+	}
+
+	// Process events within the time range
+	for _, event := range events {
+		if event.Timestamp.Before(start) {
+			continue
+		}
+		if event.Timestamp.After(end) {
+			break
+		}
+
+		if event.Status == "stopped" || event.Status == "unhealthy" {
+			if !isDown {
+				isDown = true
+				downStart = event.Timestamp
+			}
+		} else if event.Status == "running" || event.Status == "healthy" {
+			if isDown {
+				downTime += event.Timestamp.Sub(downStart)
+				isDown = false
+			}
+		}
+	}
+
+	// If still down at end time
+	if isDown {
+		downTime += end.Sub(downStart)
+	}
+
+	return downTime
+}
+
+// GetAllUptimeStats returns uptime statistics for all services
+func (ut *UptimeTracker) GetAllUptimeStats() map[string]models.UptimeStatistics {
+	ut.mutex.RLock()
+	defer ut.mutex.RUnlock()
+
+	stats := make(map[string]models.UptimeStatistics)
+	for serviceID := range ut.events {
+		stats[serviceID] = ut.CalculateUptimeStats(serviceID, nil)
+	}
+
+	return stats
+}

--- a/web/src/components/Sidebar/Sidebar.tsx
+++ b/web/src/components/Sidebar/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   Search,
   Users,
   Monitor,
+  Clock,
 } from "lucide-react";
 
 interface SidebarProps {
@@ -56,6 +57,12 @@ export function Sidebar({
       label: "Metrics",
       icon: <BarChart3 className="w-5 h-5" />,
       description: "System performance",
+    },
+    {
+      id: "uptime",
+      label: "Uptime Stats",
+      icon: <Clock className="w-5 h-5" />,
+      description: "Service uptime statistics",
     },
     {
       id: "logs",

--- a/web/src/components/UptimeStatistics/UptimeStatisticsDashboard.tsx
+++ b/web/src/components/UptimeStatistics/UptimeStatisticsDashboard.tsx
@@ -1,0 +1,246 @@
+import React, { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { RefreshCw, Clock, AlertTriangle, TrendingUp, Activity } from "lucide-react";
+import { UptimeStatistics } from "@/types";
+
+interface ServiceUptimeStats {
+  serviceName: string;
+  serviceId: string;
+  port: number;
+  status: string;
+  healthStatus: string;
+  stats: UptimeStatistics;
+}
+
+interface UptimeResponse {
+  statistics: Record<string, ServiceUptimeStats>;
+  summary: {
+    totalServices: number;
+    runningServices: number;
+    unhealthyServices: number;
+  };
+}
+
+export function UptimeStatisticsDashboard() {
+  const [uptimeData, setUptimeData] = useState<UptimeResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchUptimeStats = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const response = await fetch("/api/uptime/statistics");
+      if (!response.ok) {
+        throw new Error(`Failed to fetch uptime statistics: ${response.statusText}`);
+      }
+      const data = await response.json();
+      setUptimeData(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to fetch uptime statistics");
+      console.error("Error fetching uptime statistics:", err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUptimeStats();
+    // Refresh every 30 seconds
+    const interval = setInterval(fetchUptimeStats, 30000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const formatDuration = (nanoseconds: number): string => {
+    if (nanoseconds === 0) return "None";
+    
+    const totalSeconds = nanoseconds / 1_000_000_000;
+    const days = Math.floor(totalSeconds / 86400);
+    const hours = Math.floor((totalSeconds % 86400) / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+
+    if (days > 0) {
+      return `${days}d ${hours}h ${minutes}m`;
+    } else if (hours > 0) {
+      return `${hours}h ${minutes}m`;
+    } else if (minutes > 0) {
+      return `${minutes}m`;
+    } else {
+      return `${Math.floor(totalSeconds)}s`;
+    }
+  };
+
+  const formatMTBF = (nanoseconds: number): string => {
+    if (nanoseconds === 0) return "N/A";
+    return formatDuration(nanoseconds);
+  };
+
+  const getUptimeColor = (percentage: number): string => {
+    if (percentage >= 99) return "text-green-600";
+    if (percentage >= 95) return "text-yellow-600";
+    return "text-red-600";
+  };
+
+  const getStatusBadgeVariant = (status: string, healthStatus: string) => {
+    if (status === "running" && healthStatus === "healthy") return "default";
+    if (status === "running" && healthStatus === "unhealthy") return "destructive";
+    if (status === "running") return "secondary";
+    return "outline";
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <RefreshCw className="w-6 h-6 animate-spin mr-2" />
+        <span>Loading uptime statistics...</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <AlertTriangle className="w-12 h-12 text-red-500 mx-auto mb-4" />
+        <h3 className="text-lg font-semibold text-red-700 mb-2">Error Loading Uptime Statistics</h3>
+        <p className="text-red-600 mb-4">{error}</p>
+        <Button onClick={fetchUptimeStats} variant="outline">
+          <RefreshCw className="w-4 h-4 mr-2" />
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  if (!uptimeData) {
+    return <div className="p-8 text-center">No uptime data available</div>;
+  }
+
+  const services = Object.values(uptimeData.statistics);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex justify-between items-center">
+        <div>
+          <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
+            Service Uptime Statistics
+          </h2>
+          <p className="text-gray-600 dark:text-gray-400 mt-1">
+            Monitor service availability and reliability metrics
+          </p>
+        </div>
+        <Button onClick={fetchUptimeStats} variant="outline" size="sm">
+          <RefreshCw className={`w-4 h-4 mr-2 ${isLoading ? "animate-spin" : ""}`} />
+          Refresh
+        </Button>
+      </div>
+
+      {/* Summary Cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total Services</CardTitle>
+            <Activity className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{uptimeData.summary.totalServices}</div>
+          </CardContent>
+        </Card>
+        
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Running Services</CardTitle>
+            <TrendingUp className="h-4 w-4 text-green-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-green-600">
+              {uptimeData.summary.runningServices}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Unhealthy Services</CardTitle>
+            <AlertTriangle className="h-4 w-4 text-red-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-red-600">
+              {uptimeData.summary.unhealthyServices}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Service Statistics Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <Clock className="w-5 h-5 mr-2" />
+            Service Uptime Details
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <table className="w-full table-auto">
+              <thead>
+                <tr className="border-b">
+                  <th className="text-left py-3 px-4 font-semibold">Service</th>
+                  <th className="text-left py-3 px-4 font-semibold">Status</th>
+                  <th className="text-right py-3 px-4 font-semibold">24h Uptime</th>
+                  <th className="text-right py-3 px-4 font-semibold">7d Uptime</th>
+                  <th className="text-right py-3 px-4 font-semibold">Restarts</th>
+                  <th className="text-right py-3 px-4 font-semibold">MTBF</th>
+                  <th className="text-right py-3 px-4 font-semibold">24h Downtime</th>
+                </tr>
+              </thead>
+              <tbody>
+                {services.map((service) => (
+                  <tr key={service.serviceId} className="border-b hover:bg-gray-50 dark:hover:bg-gray-800">
+                    <td className="py-3 px-4">
+                      <div>
+                        <div className="font-medium">{service.serviceName}</div>
+                        <div className="text-sm text-gray-500">Port {service.port}</div>
+                      </div>
+                    </td>
+                    <td className="py-3 px-4">
+                      <Badge 
+                        variant={getStatusBadgeVariant(service.status, service.healthStatus)}
+                        className="text-xs"
+                      >
+                        {service.status === "running" ? service.healthStatus : service.status}
+                      </Badge>
+                    </td>
+                    <td className={`py-3 px-4 text-right font-medium ${getUptimeColor(service.stats.uptimePercentage24h)}`}>
+                      {service.stats.uptimePercentage24h.toFixed(2)}%
+                    </td>
+                    <td className={`py-3 px-4 text-right font-medium ${getUptimeColor(service.stats.uptimePercentage7d)}`}>
+                      {service.stats.uptimePercentage7d.toFixed(2)}%
+                    </td>
+                    <td className="py-3 px-4 text-right">
+                      {service.stats.totalRestarts}
+                    </td>
+                    <td className="py-3 px-4 text-right text-sm">
+                      {formatMTBF(service.stats.mtbf)}
+                    </td>
+                    <td className="py-3 px-4 text-right text-sm">
+                      {formatDuration(service.stats.totalDowntime24h)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          
+          {services.length === 0 && (
+            <div className="text-center py-8 text-gray-500">
+              No services available
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/containers/MainContentRenderer.tsx
+++ b/web/src/containers/MainContentRenderer.tsx
@@ -9,6 +9,7 @@ import { AutoDiscoveryModal } from "@/components/AutoDiscoveryModal/AutoDiscover
 import { ConfigurationManager } from "@/components/ConfigurationManager/ConfigurationManager";
 import { GlobalEnvModal } from "@/components/GlobalEnvModal/GlobalEnvModal";
 import { GlobalConfigModal } from "@/components/GlobalConfigModal/GlobalConfigModal";
+import { UptimeStatisticsDashboard } from "@/components/UptimeStatistics/UptimeStatisticsDashboard";
 import { Service } from "@/types";
 import { useProfile } from "@/contexts/ProfileContext";
 
@@ -90,6 +91,8 @@ export function MainContentRenderer({
             services={servicesData.services}
           />
         );
+      case "uptime":
+        return <UptimeStatisticsDashboard />;
       case "logs":
         return (
           <LogAggregationModal

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -11,11 +11,22 @@ export interface ResponseTime {
   status: number;
 }
 
+export interface UptimeStatistics {
+  totalRestarts: number;
+  uptimePercentage24h: number;
+  uptimePercentage7d: number;
+  mtbf: number; // Mean Time Between Failures in nanoseconds
+  lastDowntime: string | null;
+  totalDowntime24h: number; // Duration in nanoseconds
+  totalDowntime7d: number; // Duration in nanoseconds
+}
+
 export interface ServiceMetrics {
   responseTimes: ResponseTime[];
   errorRate: number;
   requestCount: number;
   lastChecked: string;
+  uptimeStats: UptimeStatistics;
 }
 
 export interface ServiceDependency {


### PR DESCRIPTION
- Add comprehensive uptime tracking with UptimeStatistics model
- Implement uptime tracking service with singleton pattern
- Integrate uptime events in service lifecycle (start/stop/restart)
- Add API endpoints for uptime statistics (/api/uptime/statistics)
- Create React dashboard component for uptime visualization
- Add sidebar navigation for uptime statistics
- Track metrics: uptime percentage (24h/7d), MTBF, restarts, downtime
- Include color-coded uptime indicators and auto-refresh functionality
- Add detailed documentation in UPTIME_STATISTICS.md

This feature provides operational insights into service reliability,
helps with SLA monitoring, and enables proactive maintenance.